### PR TITLE
Changed places of strict types

### DIFF
--- a/Plugin/Model/Shipping/ShippingAddEstimateFlagToRequestPlugin.php
+++ b/Plugin/Model/Shipping/ShippingAddEstimateFlagToRequestPlugin.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @author Calcurates Team
  * @copyright Copyright © 2020 Calcurates (https://www.calcurates.com)
@@ -6,7 +9,6 @@
  * @package Calcurates_ModuleMagento
  */
 
-declare(strict_types=1);
 
 namespace Calcurates\ModuleMagento\Plugin\Model\Shipping;
 


### PR DESCRIPTION
strict_types declaration must be the very first statement in the script
otherwise shipping methods/ rates cannot be pulled on front-end / admin
Other files might need this fix as well